### PR TITLE
make compatible with lowercase x-debug-token-link header of symfony serve

### DIFF
--- a/panel.js
+++ b/panel.js
@@ -15,7 +15,7 @@ chrome.storage.sync.get({
         function (request) {
             if ('OPTION' !== request.request.method) {
                 const xdebugTokenLink = request.response.headers.find(header => {
-                    return ('X-Debug-Token-Link' === header.name);
+                    return ('x-debug-token-link' === header.name || 'X-Debug-Token-Link' === header.name);
                 });
                 if (xdebugTokenLink) {
                     profiler.src = xdebugTokenLink.value + '?panel=' + defaultPage;


### PR DESCRIPTION
Great extension! Unfortunately it didn't work on localhost properly when using the 'symfony serve' simple PHP server, which seems to lowercase the x-debug-token-link header. This quick fix now makes it work both on apache title case X-Debug-Token-Link headers as well as the lowercase version of the header.